### PR TITLE
bump golang version

### DIFF
--- a/gometalinter/Dockerfile
+++ b/gometalinter/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10 as buildstep
+FROM golang:1.11 as buildstep
 
 RUN go get -d github.com/alecthomas/gometalinter
 WORKDIR /go/src/github.com/alecthomas/gometalinter
@@ -7,17 +7,17 @@ RUN go install -v github.com/alecthomas/gometalinter
 
 RUN go get -d golang.org/x/lint/golint
 WORKDIR /go/src/golang.org/x/lint/golint
-RUN git checkout 06c8688daad7faa9da5a0c2f163a3d14aac986ca # July 2nd 2018
+RUN git checkout c67002cb31c3a748b7688c27f20d8358b4193582 # Oct 11 2018
 RUN go install -v golang.org/x/lint/golint
 
 RUN go get -d github.com/opennota/check
 WORKDIR /go/src/github.com/opennota/check
-RUN git checkout d583513b5d849e66ee7c5d03c631ed2f03253680 # July 31st 2018
+#RUN git checkout 0c771f5545ff495a81aad2916c3f16add0cd3b55 # Sep 11 2018
 RUN go install -v github.com/opennota/check/cmd/...
 
 RUN go get -d honnef.co/go/tools/cmd/...
 WORKDIR /go/src/honnef.co/go/tools
-RUN git checkout 88497007e8588ea5b6baee991f74a1607e809487 # July 28st 2018
+#RUN git checkout 88497007e8588ea5b6baee991f74a1607e809487 # Sep 20 2018
 RUN go install -v honnef.co/go/tools/cmd/...
 
 RUN go get -d github.com/kisielk/errcheck
@@ -27,7 +27,7 @@ RUN go install -v github.com/kisielk/errcheck
 
 RUN go get -d github.com/securego/gosec/cmd/...
 WORKDIR /go/src/github.com/securego/gosec
-RUN git checkout 1.0.0
+RUN git checkout 1.2.0
 RUN go install -v github.com/securego/gosec/cmd/...
 
 RUN go get -d github.com/client9/misspell
@@ -36,5 +36,5 @@ RUN git checkout v0.3.4
 RUN go install -v github.com/client9/misspell/cmd/...
 
 
-FROM golang:1.10
+FROM golang:1.11
 COPY --from=buildstep /go/bin/* /usr/local/bin/

--- a/gometalinter/Dockerfile
+++ b/gometalinter/Dockerfile
@@ -12,12 +12,12 @@ RUN go install -v golang.org/x/lint/golint
 
 RUN go get -d github.com/opennota/check
 WORKDIR /go/src/github.com/opennota/check
-#RUN git checkout 0c771f5545ff495a81aad2916c3f16add0cd3b55 # Sep 11 2018
+RUN git checkout 0c771f5545ff495a81aad2916c3f16add0cd3b55 # Sep 11 2018
 RUN go install -v github.com/opennota/check/cmd/...
 
 RUN go get -d honnef.co/go/tools/cmd/...
 WORKDIR /go/src/honnef.co/go/tools
-#RUN git checkout 88497007e8588ea5b6baee991f74a1607e809487 # Sep 20 2018
+RUN git checkout 88497007e8588ea5b6baee991f74a1607e809487 # July 28 2018
 RUN go install -v honnef.co/go/tools/cmd/...
 
 RUN go get -d github.com/kisielk/errcheck


### PR DESCRIPTION
**Description**
Update golang version to 1.11 currently used in drone CI.
The need for this change is related with bug: https://github.com/golang/go/issues/15867 which exists in version 1.10 and causes drone failures.